### PR TITLE
Use url from prepped instead of what is passed in

### DIFF
--- a/awsrequests/__init__.py
+++ b/awsrequests/__init__.py
@@ -122,7 +122,7 @@ class AwsRequester(object):
                                hooks=hooks
                                )
         prepped = req.prepare()
-        aws_auth_headers = get_headers_for_request(url,
+        aws_auth_headers = get_headers_for_request(prepped.url,
                                                    self.region,
                                                    'execute-api',
                                                    self.access_key,


### PR DESCRIPTION
prepped gets the params mashed in from requests so that when the aws_auth_headers is generated it can do calculations on full url. 
